### PR TITLE
Improve resource validation in sprint velocity calculations

### DIFF
--- a/sprint_velocity.py
+++ b/sprint_velocity.py
@@ -78,6 +78,15 @@ def compute_effective_days(resources, sprint_days):
                     f"Resource '{name}' field '{field}' must be between 0 and 100"
                 )
 
+        if last_pto > sprint_days:
+            raise ValueError(
+                f"Resource '{name}' last_pto_days ({last_pto}) exceeds sprint days ({sprint_days})"
+            )
+        if next_pto > sprint_days:
+            raise ValueError(
+                f"Resource '{name}' next_pto_days ({next_pto}) exceeds sprint days ({sprint_days})"
+            )
+
         last_eff = (sprint_days - last_pto) * (last_pct / 100)
         next_eff = (sprint_days - next_pto) * (next_pct / 100)
         total_last += last_eff

--- a/tests/test_sprint_velocity.py
+++ b/tests/test_sprint_velocity.py
@@ -63,6 +63,54 @@ def test_compute_effective_days_single():
     assert rd[0]["Eff Days Next"] == pytest.approx(8.0)
 
 
+def test_compute_effective_days_missing_key():
+    resources = [{
+        "name": "X",
+        "last_pto_days": 1,
+        "last_pct_avail": 50,
+        "next_pto_days": 2,
+        # Missing next_pct_avail
+    }]
+    with pytest.raises(ValueError):
+        sv.compute_effective_days(resources, 10)
+
+
+def test_compute_effective_days_negative_pto():
+    resources = [{
+        "name": "Y",
+        "last_pto_days": -1,
+        "last_pct_avail": 50,
+        "next_pto_days": 0,
+        "next_pct_avail": 100,
+    }]
+    with pytest.raises(ValueError):
+        sv.compute_effective_days(resources, 10)
+
+
+def test_compute_effective_days_negative_percentage():
+    resources = [{
+        "name": "Y",
+        "last_pto_days": 0,
+        "last_pct_avail": -5,
+        "next_pto_days": 0,
+        "next_pct_avail": 100,
+    }]
+    with pytest.raises(ValueError):
+        sv.compute_effective_days(resources, 10)
+
+
+def test_compute_effective_days_percentage_out_of_range():
+    resources = [{
+        "name": "Z",
+        "last_pto_days": 0,
+        "last_pct_avail": 150,
+        "next_pto_days": 0,
+        "next_pct_avail": 100,
+    }]
+    with pytest.raises(ValueError):
+        sv.compute_effective_days(resources, 10)
+
+
 def test_perform_scaling_normal_cases():
     raw, scaled = sv.perform_scaling(10, 5, 10)
     assert raw == pytest.approx(20.0)

--- a/tests/test_sprint_velocity.py
+++ b/tests/test_sprint_velocity.py
@@ -111,6 +111,42 @@ def test_compute_effective_days_percentage_out_of_range():
         sv.compute_effective_days(resources, 10)
 
 
+def test_compute_effective_days_pto_exceeds_sprint_days_last():
+    resources = [{
+        "name": "TooMuch",
+        "last_pto_days": 11,
+        "last_pct_avail": 100,
+        "next_pto_days": 0,
+        "next_pct_avail": 100,
+    }]
+    with pytest.raises(ValueError):
+        sv.compute_effective_days(resources, 10)
+
+
+def test_compute_effective_days_pto_exceeds_sprint_days_next():
+    resources = [{
+        "name": "TooMuch",
+        "last_pto_days": 0,
+        "last_pct_avail": 100,
+        "next_pto_days": 11,
+        "next_pct_avail": 100,
+    }]
+    with pytest.raises(ValueError):
+        sv.compute_effective_days(resources, 10)
+
+
+def test_compute_effective_days_non_numeric():
+    resources = [{
+        "name": "Invalid",
+        "last_pto_days": "five",
+        "last_pct_avail": 100,
+        "next_pto_days": 0,
+        "next_pct_avail": 100,
+    }]
+    with pytest.raises(ValueError):
+        sv.compute_effective_days(resources, 10)
+
+
 def test_perform_scaling_normal_cases():
     raw, scaled = sv.perform_scaling(10, 5, 10)
     assert raw == pytest.approx(20.0)


### PR DESCRIPTION
## Summary
- validate required resource fields and value ranges in `compute_effective_days`
- add tests covering missing keys, negative values, and out-of-range percentages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68913fab5fb8833094a6e4b3dc8f6e8d