### PR TITLE
Centralize version constant

### DIFF
--- a/sprint_velocity.py
+++ b/sprint_velocity.py
@@ -3,7 +3,11 @@ import json
 import math
 import pandas as pd
 
-from version import __version__
+try:
+    from version import __version__
+except ImportError:  # pragma: no cover - fallback for missing module
+    __version__ = "0.0.0-dev"
+
 def load_config(path):
     """
     Load JSON configuration from the given file path.

--- a/sprint_velocity.py
+++ b/sprint_velocity.py
@@ -3,7 +3,7 @@ import json
 import math
 import pandas as pd
 
-
+from version import __version__
 def load_config(path):
     """
     Load JSON configuration from the given file path.
@@ -150,9 +150,6 @@ def calculate_velocity(config):
     }
 
     return metrics, resource_details
-
-
-__version__ = "1.0.0"
 
 
 def build_parser():

--- a/tests/test_sprint_velocity.py
+++ b/tests/test_sprint_velocity.py
@@ -1,11 +1,12 @@
 import json
 import os
 import sys
+
 import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-from version import __version__
 import sprint_velocity as sv
+from version import __version__
 
 
 def test_load_config(tmp_path):
@@ -213,8 +214,7 @@ def test_main_version_flag(monkeypatch, capsys):
         sv.main()
     assert exc.value.code == 0
     captured = capsys.readouterr()
-    assert __version__ in captured.out
-    assert sv.__version__ == __version__
+    assert captured.out.strip() == f"sprint_velocity.py {__version__}"
 
 
 def test_main_output_flag(monkeypatch, tmp_path):

--- a/tests/test_sprint_velocity.py
+++ b/tests/test_sprint_velocity.py
@@ -4,6 +4,7 @@ import sys
 import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from version import __version__
 import sprint_velocity as sv
 
 
@@ -212,7 +213,8 @@ def test_main_version_flag(monkeypatch, capsys):
         sv.main()
     assert exc.value.code == 0
     captured = capsys.readouterr()
-    assert sv.__version__ in captured.out
+    assert __version__ in captured.out
+    assert sv.__version__ == __version__
 
 
 def test_main_output_flag(monkeypatch, tmp_path):

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,8 @@
+import re
+
+from version import VERSION_TUPLE, __version__
+
+
+def test_version_format_and_tuple():
+    assert re.match(r"^\d+\.\d+\.\d+$", __version__)
+    assert VERSION_TUPLE == tuple(map(int, __version__.split(".")))

--- a/version.py
+++ b/version.py
@@ -1,0 +1,5 @@
+"""Project version information."""
+
+__all__ = ["__version__"]
+
+__version__ = "1.0.0"

--- a/version.py
+++ b/version.py
@@ -1,5 +1,8 @@
 """Project version information."""
 
-__all__ = ["__version__"]
+__all__ = ["__version__", "VERSION_TUPLE"]
 
+# Semantic version of the project.
 __version__ = "1.0.0"
+# Tuple form for programmatic comparisons.
+VERSION_TUPLE = tuple(map(int, __version__.split('.')))


### PR DESCRIPTION
## Summary
- centralize `__version__` in new `version` module
- import version constant in `sprint_velocity` and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689148b51180833091b82605b2532f4a