### PR TITLE
Add force flag for output file overwriting

### DIFF
--- a/tests/test_sprint_velocity.py
+++ b/tests/test_sprint_velocity.py
@@ -235,3 +235,130 @@ def test_main_output_flag(monkeypatch, tmp_path):
     assert output_path.exists()
     data = json.loads(output_path.read_text())
     assert "metrics" in data and "resource_details" in data
+
+
+def test_main_output_existing_no_force(monkeypatch, tmp_path):
+    config = {
+        "sprint_days": 5,
+        "last_velocity": 100,
+        "carryover_points": 0,
+        "resources": [
+            {
+                "name": "A",
+                "last_pto_days": 0,
+                "last_pct_avail": 100,
+                "next_pto_days": 0,
+                "next_pct_avail": 100,
+            }
+        ],
+    }
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(json.dumps(config))
+    output_path = tmp_path / "out.json"
+    output_path.write_text("existing")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["sprint_velocity.py", str(cfg_path), "--output", str(output_path)],
+    )
+    with pytest.raises(SystemExit) as exc:
+        sv.main()
+    assert exc.value.code == 1
+    assert output_path.read_text() == "existing"
+
+
+def test_main_output_existing_force(monkeypatch, tmp_path):
+    config = {
+        "sprint_days": 5,
+        "last_velocity": 100,
+        "carryover_points": 0,
+        "resources": [
+            {
+                "name": "A",
+                "last_pto_days": 0,
+                "last_pct_avail": 100,
+                "next_pto_days": 0,
+                "next_pct_avail": 100,
+            }
+        ],
+    }
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(json.dumps(config))
+    output_path = tmp_path / "out.json"
+    output_path.write_text("existing")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "sprint_velocity.py",
+            str(cfg_path),
+            "--output",
+            str(output_path),
+            "--force",
+        ],
+    )
+    sv.main()
+    data = json.loads(output_path.read_text())
+    assert "metrics" in data and "resource_details" in data
+
+
+def test_output_directory_path(monkeypatch, tmp_path, capsys):
+    config = {
+        "sprint_days": 5,
+        "last_velocity": 100,
+        "carryover_points": 0,
+        "resources": [
+            {
+                "name": "A",
+                "last_pto_days": 0,
+                "last_pct_avail": 100,
+                "next_pto_days": 0,
+                "next_pct_avail": 100,
+            }
+        ],
+    }
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(json.dumps(config))
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    monkeypatch.setattr(
+        sys, "argv", ["sprint_velocity.py", str(cfg_path), "--output", str(output_dir)]
+    )
+    with pytest.raises(SystemExit) as exc:
+        sv.main()
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert "directory" in captured.err
+
+
+def test_write_permission_error(monkeypatch, tmp_path, capsys):
+    config = {
+        "sprint_days": 5,
+        "last_velocity": 100,
+        "carryover_points": 0,
+        "resources": [
+            {
+                "name": "A",
+                "last_pto_days": 0,
+                "last_pct_avail": 100,
+                "next_pto_days": 0,
+                "next_pct_avail": 100,
+            }
+        ],
+    }
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(json.dumps(config))
+    output_path = tmp_path / "out.json"
+
+    def deny(*args, **kwargs):  # pragma: no cover - simple monkeypatch helper
+        raise PermissionError("no permission")
+
+    monkeypatch.setattr(os, "open", deny)
+    monkeypatch.setattr(
+        sys, "argv", ["sprint_velocity.py", str(cfg_path), "--output", str(output_path)]
+    )
+    with pytest.raises(SystemExit) as exc:
+        sv.main()
+    assert exc.value.code == 2
+    captured = capsys.readouterr()
+    assert "Permission denied" in captured.err


### PR DESCRIPTION
## Summary
- add `--force` flag to CLI to allow overwriting existing output files
- guard against overwriting by default and wrap JSON writing with try/except
- perform atomic output writes, detect directory paths, and surface permission errors
- add tests for directory and write-permission edge cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689146f5f5c483308a04d4f36820af9a