### PR TITLE
Add flake8 linting and update tests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 100
+extend-ignore = E203, W503

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ A simple CLI tool to project and scale sprint velocity based on team availabilit
 
 - Python 3.7 or newer
 - pandas
+- pytest
+- flake8
 
 ## Installation
 
@@ -82,10 +84,11 @@ Member3              1           100            9.0              0           100
 
 ## Testing
 
-Unit tests are implemented with pytest:
+Unit tests are implemented with pytest, and flake8 is used for linting:
 
 ```bash
 python -m pytest
+flake8
 ```
 
 ## License

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pandas>=2.3.0
 pytest>=8.4.1
+flake8>=5.0.4

--- a/sprint_velocity.py
+++ b/sprint_velocity.py
@@ -12,6 +12,7 @@ try:
 except ImportError:  # pragma: no cover - fallback for missing module
     __version__ = "0.0.0-dev"
 
+
 def load_config(path):
     """
     Load JSON configuration from the given file path.
@@ -123,7 +124,9 @@ def perform_scaling(last_velocity, total_last, total_next):
       ValueError: if total_last is zero or negative (cannot scale)
     """
     if total_last <= 0:
-        raise ValueError("Cannot scale velocity: total effective days last sprint is zero or negative")
+        raise ValueError(
+            "Cannot scale velocity: total effective days last sprint is zero or negative"
+        )
     raw_scaled = last_velocity * (total_next / total_last)
     return raw_scaled, math.floor(raw_scaled)
 

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
-from sprint_velocity import write_output_json
+from sprint_velocity import write_output_json  # noqa: E402
 
 
 def test_cli_output(tmp_path):

--- a/tests/test_sprint_velocity.py
+++ b/tests/test_sprint_velocity.py
@@ -6,8 +6,8 @@ from pathlib import Path
 import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-import sprint_velocity as sv
-from version import __version__
+import sprint_velocity as sv  # noqa: E402
+from version import __version__  # noqa: E402
 
 
 def test_load_config(tmp_path):
@@ -378,4 +378,3 @@ def test_main_serialization_error(monkeypatch, tmp_path):
     with pytest.raises(SystemExit) as exc:
         sv.main()
     assert exc.value.code == 1
-


### PR DESCRIPTION
## Summary
- add flake8 config and dependency
- document linting workflow in README
- fix lint issues in code and tests

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6892c2cf6aa48330843da82f4ac3f61f