### PR TITLE
Add usage examples to CLI help

### DIFF
--- a/sprint_velocity.py
+++ b/sprint_velocity.py
@@ -3,6 +3,7 @@ import json
 import math
 import os
 import sys
+import textwrap
 from pathlib import Path
 
 import pandas as pd
@@ -165,8 +166,19 @@ def calculate_velocity(config):
 
 def build_parser():
     """Create and return the command-line argument parser."""
+    description = textwrap.dedent(
+        """
+        Calculate next sprint velocity from a configuration file.
+
+        Examples:
+          python sprint_velocity.py config.json
+          python sprint_velocity.py config.json --output results.json
+          python sprint_velocity.py config.json --output results.json --force
+        """
+    )
     parser = argparse.ArgumentParser(
-        description="Calculate next sprint velocity from a configuration file"
+        description=description,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("config", help="Path to configuration JSON file")
     parser.add_argument(


### PR DESCRIPTION
## Summary
- expand sprint_velocity.py parser description with usage examples
- enable RawDescriptionHelpFormatter for multiline help text

## Testing
- `python sprint_velocity.py --help`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892c9fa8f008330b5e30fb45c6bfd26