### PR TITLE
docs: clarify CLI help examples

### DIFF
--- a/sprint_velocity.py
+++ b/sprint_velocity.py
@@ -171,9 +171,12 @@ def build_parser():
         Calculate next sprint velocity from a configuration file.
 
         Examples:
-          python sprint_velocity.py config.json
-          python sprint_velocity.py config.json --output results.json
-          python sprint_velocity.py config.json --output results.json --force
+          Basic run:
+            python sprint_velocity.py config.json
+          Save results to a file:
+            python sprint_velocity.py config.json --output results.json
+          Force overwrite the results file:
+            python sprint_velocity.py config.json --output results.json --force
         """
     )
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
## Summary
- expand help description with basic, output-saving, and force overwrite examples

## Testing
- `python sprint_velocity.py --help`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689396aeff3883309e0206a44b0c5c80